### PR TITLE
Updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 ## Development Workflow
 * `pip install mkdocs`
+* `pip install pymdown-extensions`
 * `git clone git@github.com:veg/hyphy-site.git`
 * `mkdocs build`
 * `mkdocs serve`

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -1,47 +1,57 @@
-This glossary provides definitions for terms in the HyPhy-Vision reports for each method. See [here](./selection-methods) for descriptions of each method. 
+This glossary provides definitions for terms in the HyPhy-Vision reports for each method. See [here](./selection-methods) for descriptions of each method.
 
 
-## aBSREL Glossary
+## Shared Terms
+Terms defined below pertain to most HyPhy method results.
+
+* ***log* L** - The log likelihood estimate of the respective model fit.
+* **\# par.** - The number of estimated parameters in the respective model.
+* **Time to fit** - Total clock time to fit the respective model.
+* **AIC<sub>c</sub>**  - [Small-sample Akaike Information Criterion](http://www.tandfonline.com/doi/abs/10.1080/03610927808827599) score.
+* **L<sub>tree</sub>** - The tree length under the respective model, where tree length represents the expected number of substitutions per site.
+
 
 <!-- I think the following has been removed from vision
 ### Summary Statistics **\\\\ has this info since been removed?**
 * **number of sequences** - the number of sequences present in the input file
 * **number of variants** - the number of variants present in the input file
 * **number of branches** - the number of branches in the phylogeny
---> 
+-->
+
+
+## aBSREL Glossary
+
 
 ### Summary: Tree Table
 The Tree Table reports a summary of the inferred the number of rate classes across branches.
 
-* **\(\omega\) rate classes** - Number of rate classes inferred, where \(\omega\) represents the ratio of nonsynonymous to synonymous substitution rates
-* **\# of branches** - The number of branches inferred to have the respective number of \(\omega\) rate classes 
-* **% of branches** - The proportion of branches inferred to have the respective number of \(\omega\) rate classes 
-* **% of tree length** - The percent of the total tree length inferred to have the respective number of \(\omega\) rate classes 
-* **\# under selection** - The number of branches inferred to have undergone positive selection (a rate class of \(\omega>1\)) at the designated p-value threshold, after correction for multiple testing
+* **$\boldsymbol \omega$ rate classes** - Number of $\omega$ rate classes inferred.
+* **\# of branches** - The number of branches inferred to have the respective number of $\omega$ rate classes.
+* **% of branches** - The proportion of branches inferred to have the respective number of $\omega$ rate classes.
+* **% of tree length** - The percentage of the total tree length inferred to have the respective number of $\omega$ rate classes.
+* **\# under selection** - The number of branches inferred to have undergone positive selection (a rate class of $\omega>1$) at the designated p-value threshold, after correction for multiple testing.
 
 ### Summary: Model Fits Table
 
 The Model Fits Table reports a summary of the models fit to the data.
 
-* **Model** - The model fit.
-    * **MG94** - Refers to the baseline model fit, using the standard [Must-Gaut 1994](https://www.ncbi.nlm.nih.gov/labs/articles/7968485/) model (specifically the [MG94-REV](https://www.ncbi.nlm.nih.gov/pubmed/15703242) formulation), where a single \(\omega\) rate category is inferred per branch. 
-    * **Full Model** - Refers to the full aBSREL model fit to the tree, with the number of \(\omega\) categories per branch inferred using the adaptive algorithm.
-* ***log* L** - The log likelihood estimate of the respective model fit.
-* **\# par.** - The number of estimated parameters in the respective model.
-* **Time to fit** - Total clock time to fit the respective model.
-* **AIC<sub>c</sub>**  - Resulting small-sample Akaike Information Criterion [(Sugiura, 1978, Commun. Stat. Theory Methods, A7:13)](http://www.tandfonline.com/doi/abs/10.1080/03610927808827599) score, calculated when inferring the optimal number of \(\omega\) rate categories at each branch in the phylogeny.
-* **L<sub>tree</sub>** - The tree length under the respective model, where tree length represents the expected number of substitutions per site.
+* **MG94** - The baseline model fit of [MG94xREV](selection-methods/#mg94xrev-framework) that infers a single $\omega$ per branch.
+* **Full Model** - The full aBSREL model fit to the tree, where the number of $\omega$ classes per branch is inferred adaptively.
+
+See these [Shared Terms](glossary/#shared-terms) for additional reported information.
+
+
 
 
 ### Full Table
 The full Results Table reports inferences of positive selection for each branch.
 
-* **Name** - Branch of interest, where bolded rows refer to branches inferred to have experienced position selection at the designated p-value threshold  
-* **B** - **Branch length for the branch of interest -- CURRENTLY EMPTY IN THE TABLE**
-* **LRT** - Likelihood ratio test statistic for selection, comparing the aBSREL model to a null model where any categories of \(\omega>1\) are disallowed 
-* **Test p-value** - P-value corrected for multiple testing using the Holm-Bonferroni correction [(Holm, 1979, Scand. J. Statist., 6:65)](https://www.jstor.org/stable/4615733)
-* **Uncorrected p-value** - Raw p-value before correction for multiple testing
-* **\(\omega\) distribution over sites** - Inferred \(\omega\) estimates and respective proportion of sites along the respective branch
+* **Name** - Branch of interest, where bolded rows indicate that the branch shows evidence, at the designated p-value threshold, of positive selection.
+* **B** - Optimized (under the full aBSREL model) branch length for the branch of interest
+* **LRT** - Likelihood Ratio Test statistic for selection. This LRT was calculated by comparing the fitted aBSREL model to the null model where rate classes of $\omega>1$ are disallowed.
+* **Test p-value** - P-value corrected for multiple testing using the [Holm-Bonferroni correction](https://www.jstor.org/stable/4615733). These values are only calculated for branches with uncorrected p-values less than 1.
+* **Uncorrected p-value** - Raw p-value before correction for multiple testing.
+* **$\boldsymbol \omega$ distribution over sites** - Inferred $\omega$ estimates and respective proportion of sites along the respective branch.
 
 
 <!------------------------------------------------------------------------------------->
@@ -51,15 +61,20 @@ The full Results Table reports inferences of positive selection for each branch.
 
 ### Summary: Model Fits Table
 
-The Model Fits Table reports a summary of the models fit to the data. Corresponding plots of \(\omega\) distributions display inferred \(\omega\) values, and when applicable, how selection intensity compares across \(\omega\) categories between test and reference branches.
+The Model Fits Table reports a summary of the models fit to the data. Corresponding plots of $\omega$ distributions display inferred $\omega$ class values, and when applicable, how selection intensity compares across $\omega$ classes between test and reference branches.
 
-* **Model** - The model fit. For a more thorough description of these models, see [this description of RELAX](selection-methods/#RELAX).
-    * **Null** - This model represents the null model used to test for selection, where the selection intensity parameter *k* is set to 1 for both branch sets (reference and test).
-    * **Alternative** - This model represents the alternative model used to test for selection, where the selection intensity parameter *k* is allowed for vary on the "test" partition of branches. Note that all test branches will share the value for *k*.
-    * **Partitioned MG94xREV** - This baseline model fits a single \(\omega\) value to each of the two branch sets (reference and test), respectively.
-    * **Partitioned Descriptive** - This model infers three \(\omega\) categories distributions for each partition, respectively, without using the selection intensity parameter *k* (e.g. k=1 throughout). 
-    * **General Descriptive** - This model fits three \(\omega\) categories to the entire phylogeny, i.e. shared across all branches. This model then infers a single selection intensity parameter *k* for each branch. 
+Fitted models include the following:
 
+* **Null** - This model represents the null model used to test for selection relaxation. Here, the selection intensity parameter *k* is set to 1 for both branch sets (reference and test).
+* **Alternative** - This model represents the alternative model used to test for selection relaxation. Here, the selection intensity parameter *k* is allowed for vary on the "test" partition of branches. Note that a single *k* is inferred and shared across all test branches.
+* **Partitioned MG94xREV** - This baseline model fits a single $\omega$ value to each of the two branch sets (reference and test), respectively.
+* **Partitioned Descriptive** - This model infers three $\omega$ classes distributions for each partition, respectively, without using the selection intensity parameter *k* (e.g. k=1 throughout).
+* **General Descriptive** - This model fits three $\omega$ classes to the entire phylogeny, i.e. shared across all branches. This model then infers a single selection intensity parameter *k* for each branch.
+
+The following information is additionally reported for each model (as well as these [Shared Terms](glossary/#shared-terms)):
+
+* **Branch set** - The set of branches (all, test, or reference) for which the given set of $\omega$ rate classes were inferred.
+* **$\boldsymbol{\omega_{<1,2,3>}}$** - The inferred $\omega$ value for the respective rate class ($\omega_1$, $\omega_2$, or $\omega_3$). The value in parentheses indicates the proportion of sites inferred to belong to this rate class.
 
 <!------------------------------------------------------------------------------------->
 
@@ -70,33 +85,37 @@ The Model Fits Table reports a summary of the models fit to the data. Correspond
 ### Summary: Model Fits Table
 
 The Model Fits Table reports a summary of the models fit to the data.
+Fitted models include the following:
 
-* **Model** - The model fit.
-    * **Unconstrained model** - Refers to the alternative model fit to the data where the \(\omega\) rate category used to test for selection is permitted to exceed 1 on the foreground branches.  
-    * **Constrained model** - Refers to the null model fit to the data where the background and foreground branches share all \(\omega\) rate categories, specifically where the \(\omega\) rate category used to test for selection is constrained to equal 1.
-* ***log* L** - The log likelihood estimate of the respective model fit.
-* **\# par.** - The number of estimated parameters in the respective model.
-* **Time to fit** - Total clock time to fit the respective model.
-* **AIC<sub>c</sub>**  - Resulting small-sample Akaike Information Criterion [(Sugiura, 1978, Commun. Stat. Theory Methods, A7:13)](http://www.tandfonline.com/doi/abs/10.1080/03610927808827599) score.
-* **L<sub>tree</sub>** - The tree length under the respective model, where tree length represents the expected number of substitutions per site.
-* **Branch Set** - ** I think this should go: The specified name for the set of branches with inferred rates under this model**
-* **ω<sub><1,2,3></sub>** - The inferred \(\omega\) value for the given rate category (1, 2, or 3) with the respective proportion of sites inferred to belong to this category.
+* **Constrained model** - This model represents the null model used in the BUSTED hypothesis test. For this model, the background and foreground branch partitions share all $\omega$ rate classes, but the value $\omega$ rate class used to test for selection is constrained to equal 1 (i.e. $\omega_3 = 1$ for both the background and foreground branches).
+
+* **Unconstrained model** - This model represents the alternative model used in the BUSTED hypothesis test. For this model, the value for $\omega$ rate class used to test for selection is permitted to exceed 1 on the foreground branches. (i.e. $\omega_3 > 1$ on foreground branches).
+
+
+The following information is additionally reported for each model (as well as these [Shared Terms](glossary/#shared-terms):
+* **$\boldsymbol{\omega_{<1,2,3>}}$** - The inferred $\omega$ value for the respective rate class ($\omega_1$, $\omega_2$, or $\omega_3$). The value in parentheses indicates the proportion of sites inferred to belong to this rate class.
 
 
 ### Summary: Model Evidence Ratios Per Site
 
-This plot shows the "Evidence Ratio", displayed as the scaled likelihood ratio test statistic, indicating evidence for whether a given site experienced positive selection each model. The *Constrained* evidence ratio refers to sitewise quantities calculated from comparing the Constrained (null) model fit to the Unconstrained model fit, as fit to the entire data set. The *Optimized Null* evidence ratios compare *site-specific* fits between the Constrained and Unconstrained models. For more detailed information on the difference between the Constrained and Optimized Null evidence ratios, see [this description of BUSTED](selection-methods/#BUSTED). **Importantly, These values should not be interpreted as definitive estimates of selection at individual sites.** 
+This plot shows the "Evidence Ratio" (ER), displayed as the scaled Likelihood Ratio Test statistic. The ER is calculated for a given site *s* ($ER^s$) using the likelihoods from a fitted null model ($L_{null}$) and a fitted alternative model ($L_{alt}$) at the site of interest *s*:
+
+$$ ER^s = 2 \times \log\big{(}{ \frac{ L^s_{alt}}{L^s_{null}} }\big{)} $$
+
+Evidence ratios provide *descriptive evidence* for whether a given site may have experienced positive selection. **Note that evidence ratios do not provide statistically valid evidence for selection at individuals sites.**
+
+For more detailed information on the difference between the Constrained and Optimized Null evidence ratios, see [this description of BUSTED](selection-methods/#BUSTED).
 
 ### Summary: Model Evidence Ratios Per Site Table
 
 This table provides site-specific inference information.
 
 * **Site Index** - The codon site of interest.
-* **Unconstrained Likelihood** - The log likelihood score for the codon site of interest, calculated from the Unconstrained model fit.
+* **Unconstrained Likelihood** - The log likelihood score for the codon site of interest, calculated from the Unconstrained Model fit.
 * **Constrained Likelihood** - The log likelihood score for the codon site of interest, calculated from the Constrained Model fit.
-* **Optimized Null Likelihood** - The log likelihood score for the codon site of interest, calculated from the Constrained Model fit to the specific codon site of interest (as opposed to a fit to the entire data set).
-* **Constrained Evidence Ratio** - Evidence ratio for positive selection at the given codon site, using the Constrained model as the null model.
-* **Optimized Null Evidence Ratio** - Evidence ratio for selection at the given codon site under the Optimized Null model, i.e. by fitting the Constrained (null) and Unconstrained (alternative) model only to the specific site of interest.
+* **Optimized Null Likelihood** - The log likelihood score for the codon site of interest, calculated from the Optimized Null Model fit. The Optimized Null model is the Constrained model whose parameters have been re-optimized for this specific site.
+* **Constrained Evidence Ratio** - Evidence ratio for positive selection at the given codon site, using the Constrained Model as the null model.
+* **Optimized Null Evidence Ratio** - Evidence ratio for selection at the given codon site, using the Optimized Null model as the null model.
 
 
 

--- a/docs/other-methods.md
+++ b/docs/other-methods.md
@@ -1,0 +1,9 @@
+HyPhy provides many other methods which do not specifically test selection. Methods include the following:
+
+## GARD (**G**enetic **A**lgorithm for **R**ecombination **D**etection)
+
+## PRIME (**PR**operty **I**nformed **M**odels of **E**volution)
+
+## AA relative rates
+
+## Ancestral State Reconstruction

--- a/docs/selection-methods.md
+++ b/docs/selection-methods.md
@@ -1,13 +1,15 @@
 ## Choosing a method for selection inference
 
-HyPhy provides a suite of diverse phylogenetic methodologies for testing specific hypotheses about selection in protein-coding multiple sequence alignments. Which method you select will depend on your specific question:
+HyPhy provides a suite of diverse phylogenetic methodologies for testing specific hypotheses about selection in protein-coding and/or amino-acid multiple sequence alignments. Which method you select will depend on your specific question:
 
 ### Are individual sites subject to *pervasive* (across the whole phylogeny) positive or purifying selection?
-* [FEL](selection-methods/#FEL) (**F**ixed **E**fects **L**ikelihood) is suitable for small-to-medium sized data sets
+* [FEL](selection-methods/#FEL) (**F**ixed **E**fects **L**ikelihood) is suitable for small-to-medium sized data sets.
+* [SLAC](selection-methods/#SLAC) (**S**ingle-**L**ikelihood **A**ncestor **C**ounting) is an approximate method with accuracy similar to FEL, but suitable for larger datasets. However, SLAC is not suitable for highly-diverged sequences.
 * [FUBAR](selection-methods/#fubar) (**F**ast, **U**nconstrained **B**ayesian **A**pp**R**oximation) is suitable for medium-to-large data sets and is expected to have more power than FEL for detecting pervasive selection at sites.
 
-### Are individual sites subject to *episodic* positive or purifying selection?
-* [MEME](selection-methods/#MEME) (**M**ixed **E**ffects **M**odel of **E**volution) tests for episodic (e.g. at a subset of branches) selection at individual sites. **MEME is the preferred approach for inferring site-specific selection** and does not accept *a priori* branch specifications.
+
+### Are individual sites subject to *episodic* (at a subset of branches) positive or purifying selection?
+* [MEME](selection-methods/#MEME) (**M**ixed **E**ffects **M**odel of **E**volution) tests for episodic selection at individual sites. **MEME is the preferred approach for detecting positive selection at individual sites** and does not accept *a priori* branch specifications.
 * [aBSREL](selection-methods/#aBSREL) (**a**daptive **B**ranch-**S**ite **R**andom **E**ffects **L**ikelihood) is an improved version of the common "branch-site" class of models. aBSREL allows either for *a priori* specification of branch(es) to test for selection, or can test each lineage for selection in an exploratory fashion. Note that the exploratory approach will sacrifice power.
 
 
@@ -15,27 +17,47 @@ HyPhy provides a suite of diverse phylogenetic methodologies for testing specifi
 * [BUSTED](selection-methods/#BUSTED) (**B**ranch-**S**ite **U**nrestricted **S**tatistical **T**est for **E**pisodic **D**iversification) will test for gene-wide selection at pre-specified lineages. This method is particularly useful for relatively small datasets (fewer than 10 taxa) where other methods may not have sufficient power to detect selection. **This method is not suitable for identifying specific sites subject to positive seleciton.**
 
 ### Has gene-wide selection pressure been relaxed or intensified along a certain subset of branches?
-* [RELAX](selection-methods/#RELAX) tests for a relaxation (e.g. where purifying selection has become less stringent) or an intensification (e.g. where purifying selection has become stronger) of selection pressures along a specified set of "test" branches. **This method is not suitable for the detection of positive selection.**
+* [RELAX](selection-methods/#RELAX) tests for a relaxation (e.g. where purifying selection has become less stringent) or an intensification (e.g. where purifying selection has become stronger) of selection pressures along a specified set of "test" branches. **This method is not suitable for detecting positive selection.**
+
+<!--
+### Are individual sites within a gene subject to *directional* selection, i.e. selection pressure to evolve towards a specific set of amino acids?
+* [FADE](selection-methods/#FADE) tests for directional selection at specific sites in *protein* alignments.
+-->
 
 <!--------------------------------------------------------------------------------------->
 ## MG94xREV Framework
-All methods rely, to some extent, on the MG94xREV codon model, a generalized extension of the [MG94 model](https://www.ncbi.nlm.nih.gov/labs/articles/7968485/) (MG94xREV) that allows for a full GTR mutation rate matrix:
+All methods rely, to some extent, on the MG94xREV codon model, a generalized extension of the [MG94 model](https://www.ncbi.nlm.nih.gov/labs/articles/7968485/) that allows for a full GTR mutation rate matrix. The MG94xREV *transition matrix* **Q** (also known as the *instantaneous rate matrix*), for the substitution from codon $i$ to codon $j$ is given by: 
 
-[rate matrix goes here with explanation of parameters, graphically]
+$$\begin{equation}
+q_{ij} = \left\{ 
+\begin{array}{rl}
+\alpha\theta_{ij}\pi_{j},         &\delta(i,j)=1, AA(i)=AA(j)     \\
+\beta\theta_{ij}\pi_{j},          &\delta(i,j)=1, AA(i)\neq AA(j) \\
+0,                                 &\delta(i,j)>1                  \\
+-\sum_{k \neq i}q_{ik},            & i=j
+\end{array} \right.
+\end{equation}$$
 
-As part of likelihood calculations, MG94xREV requires a specified set of "codon frequencies," which globally reflect codon frequencies which would be present in the *absence* of selection. HyPhy employs the [CF3x4](http://dx.doi.org/10.1371/journal.pone.0011230), a corrected version of the common F3x4 estimator (introduced in [Goldman and Yang 1994](https://www.ncbi.nlm.nih.gov/pubmed/7968486)) which accounts for biases in nucleotide composition induced by stop codons. 
+Parameters in this matrix include the following:
 
+* **The function $\boldsymbol{\delta(i,j)}$** is an indicator function that equals the number of nucleotide differences between codons $i$ and $j$; for example, $\delta(AAA,AAT) = 1$ and $\delta(AAA,CCG) = 3$. Like most other codon models, the MG94xREV model considers only single-nucleotide codon substitutions to be instantaneous. 
 
-All methods (with the partial exception of RELAX*) will perform a global MG94xREV fit to optimize branch length and nucleotide substitution parameters before proceeding to hypothesis testing. Several of these methods (FEL, FUBAR, and MEME) additionally pre-fit a GTR nucleotide model to the data, using the estimated parameters as starting values for the global MG94xREV fit, as a computational speed-up. Resulting branch length and nucleotide substitution parameters are subsequently used during model fitting for hypothesis testing.
+* $\boldsymbol{AA(i)}$ refers to the amino-acid encoded by codon $i$.
 
+* $\boldsymbol{\alpha}$ represents the *synonymous substitution rate* dS, and $\boldsymbol{\beta}$ represents the *nonsynonymous substitution rate* dN. Hence, $dN/dS = \beta/\alpha$. We refer to the $dN/dS$ ratio as simply $\omega$.
 
-*The global MG94xREV fit is only performed for the descriptive and/or exploratory versions of RELAX (see [below](selection-methods/#RELAX) for details).
+* Together, the mutation model ("REV" component of MG94xREV model) is described by two parameter sets: $\boldsymbol{\Theta}$, comprised of values $\theta_{ij}$, and $\boldsymbol{\Pi}$, comprised of values $\pi_{j}$. $\Theta$ values are the *nucleotide mutational biases*, and $\Pi$ are the *equilibrium nucleotide frequencies*.
+    
+* Not explicitly seen in this model are the *equilibrium codon frequencies*, denoted $\boldsymbol{\hat{\Pi}}$. These frequencies are estimated using nine positional nucleotide frequencies for the target nucleotides in each codon substitution. Specifically, HyPhy employs the [CF3x4](http://dx.doi.org/10.1371/journal.pone.0011230) frequency estimator, a corrected version of the common F3x4 estimator (introduced in [Goldman and Yang 1994](https://www.ncbi.nlm.nih.gov/pubmed/7968486)) which accounts for biases in nucleotide composition induced by stop codons. 
 
+Most methods (except FADE, which does not use codon data) will perform a global MG94xREV fit to optimize branch length and nucleotide substitution parameters before proceeding to hypothesis testing. Several methods (FEL, FUBAR, and MEME) additionally pre-fit a GTR nucleotide model to the data, using the estimated parameters as starting values for the global MG94xREV fit, as a computational speed-up. Resulting branch length and nucleotide substitution parameters are subsequently used as initial parameter values during model fitting for hypothesis testing.
 
 <!--------------------------------------------------------------------------------------->
 ## Synonymous Rate Variation
 
-A key component of HyPhy analyses is the inclusion of *synonymous rate variation*, meaning that dS is often allowed to vary across sites and/or branches, depending on the specific method. As such, hypothesis testing for positive selection is typically conducted by assessing whether dN is significantly greater than dS. [See this paper](https://doi.org/10.1093/molbev/msi232) for a detailed description of why incorporating synonymous rate variation into positive selection inference is likely beneficial. Importantly, this consideration of synonymous rate variation stands in contrast to methods implemented in, for example, [PAML](https://doi.org/10.1093/molbev/msm088) where dS is constrained to equal 1, and postitive selection is inferred based on whether dN () is greater than 1. 
+A key component of HyPhy methods is the inclusion of *synonymous rate variation*. In other words, dS is allowed to vary across sites and/or branches, depending on the specific method. [This paper](https://doi.org/10.1093/molbev/msi232) provides a detailed analysis demonstrating why incorporating synonymous rate variation into positive selection inference is likely beneficial. Importantly, this consideration of synonymous rate variation stands in contrast to methods implemented in, for example, [PAML](https://doi.org/10.1093/molbev/msm088) where dS is constrained to equal 1.
+
+
 
 <!--------------------------------------------------------------------------------------->
 ## FEL
@@ -50,6 +72,17 @@ After optimizing branch lengths and nucleotide substitution parameters, FEL fits
 
 
 <!--------------------------------------------------------------------------------------->
+## SLAC
+
+SLAC uses a combination of maximum-likelihood (ML) and counting approaches to infer nonsynonymous (dN) and synonymous (dS) substitution rates on a per-site basis for a given coding alignment and corresponding phylogeny. Like FEL, this method assumes that the selection pressure for each site is constant along the entire phylogeny. 
+
+SLAC begins by optimizing branch lengths and nucleotide substitution parameters under the MG94xREV model. However, rather than using ML to fit site-specific dN and dS parameters, SLAC instead uses ML to infer the most likely ancestral sequence at each node of the phylogeny. SLAC then employs a modified version of the [Suzuki-Gojobori counting method](https://doi.org/10.1093/oxfordjournals.molbev.a026042) to directly count the total number of nonsynonymous and synonymous changes which have occurred at each site. Significance is ascertained at each site using an extended binomial distribution. Importantly, due to its counting-based approach, SLAC may not be accurate for data sets with high divergence levels.
+
+**If you use SLAC in your analysis, please cite the following:** [`Kosakovsky Pond, SL and Frost, SDW. "Not So Different After All: A Comparison of Methods for Detecting Amino Acid Sites Under Selection." Mol. Biol. Evol. 22, 1208--1222 (2005).`](https://doi.org/10.1093/molbev/msi105)
+
+
+
+<!--------------------------------------------------------------------------------------->
 ## FUBAR
 
 FUBAR uses a Bayesian approach to infer nonsynoymous (dN) and synonymous (dS) substitution rates on a per-site basis for a given coding alignment and corresponding phylogeny. This method assumes that the selection pressure for each site is constant along the entire phylogeny.
@@ -58,9 +91,11 @@ Although FUBAR produces similar information to FEL, it has several key differenc
 
 * FUBAR employs a Bayesian algorithm to infer rates, and therefore it reports evidence for positive selection using *posterior probabilities* (which range from 0-1), not p-values. Generally, posterior probabilities > 0.9 are strongly suggestive of positive selection. 
 * FUBAR runs extremely quickly and is well-suited for analyzing large alignments, with hundreds or thousands of sequences. This speed-up results from the novel strategy of employing a pre-specified discrete grid of dN and dS values to be applied across sites. This approach contrasts with the time-consuming FEL strategy of fitting a new MG94xREV model at each site.
-* FUBAR may have more power than FEL, in particular when positive selection is present but relatively weak (i.e. low values of ω>1).
+* FUBAR may have more power than FEL, in particular when positive selection is present but relatively weak (i.e. low values of $\omega>1$).
 
 **If you use FUBAR in your analysis, please cite the following:** [`Murrell, B et al. "FUBAR: A Fast, Unconstrained Bayesian AppRoximation for inferring selection." Mol. Biol. Evol. 30, 1196–1205 (2013).`](https://doi.org/10.1093/molbev/mst030)
+
+
 
 <!--------------------------------------------------------------------------------------->
 ## MEME
@@ -68,25 +103,30 @@ Although FUBAR produces similar information to FEL, it has several key differenc
 MEME employs a mixed-effects maximum likelihood approach to test the hypothesis that individual sites have been subject to episodic positive or diversifying selection. 
 In other words, MEME aims to detect sites evolving under positive selection under a *proportion* of branches.
 
-The "mixed-effects" aspect of MEME refers to its modeling strategy of allowing ω rates to vary across sites, while also allowing these ω rates to vary across branches. More specifically, MEME infers two ω rate categories (\(\omega_1\) and \(\omega_2\)), and corresponding weights, for each site, shared across all branches at that site. These two ω categories share a site-specific synonymous rate dS, but differ in their nonsynonymous rates. 
-For both the null and alternative models, one rate category ω<sub>1</sub> follows the constraint ω<sub>1</sub>≤dS. The second rate category ω<sub>2</sub> is used for positive selection inference: In the null model, ω<sub>2</sub> is similarly constrained as ω<sub>2</sub>≤dS. By contrast, the alternative model places no constraints on ω<sub>2</sub>, thus representing a category of positive selection. Positive selection is inferred using the Likelihood Ratio Test between alternative and null models. 
+
+For each site, MEME infers two $\omega$ rate classes and corresponding weights representing the probability that the site evolves under $\omega$ rate class, at a given branch. Importantly, to infer $\omega$ rates, MEME infers a single $\alpha$ (dS) value and two separate $\beta$ (dN) values, $\beta^-$ and $\beta^+$, which share the same $\alpha$, per site. For both the null and alternative model, MEME enforces the constraint $\beta^- \leq \alpha$. The $\beta^+$ parameter is therefore the key difference between null and alternative models: In the null model, $\beta^+$ is constrained as in the null model: $\beta^+ \leq \alpha$, but $\beta^+$ is not constrained in the alternative model. Ultimately, positive selection for each site is inferred when $\beta^+ > \alpha$ and shown to be significant using the likelihood ratio test. 
  
 
 **If you use MEME in your analysis, please cite the following:** [`Murrell, B et al. "Detecting individual sites subject to episodic diversifying selection." PLoS Genetics 8, e1002764 (2012).`](http://dx.doi.org/10.1371/journal.pgen.1002764)
 
+
+
+
+
+
 <!--------------------------------------------------------------------------------------->
 ## aBSREL
 
-aBSREL ("adaptive Branch-Site Random Effects Likelihood) is an "adaptive" version of the commonly-used "branch-site" models, which are used to test if positive selection has occurred on a proportion of branches. As such, aBSREL models both site-level and branch-level ω heterogeneity. aBSREL, however, does not test for selection at specific sites. Instead, aBSREL will test, for each branch (or branch of interest) in the phylogeny, whether a proportion of sites have evolved under positive selection. 
+aBSREL is an improved version of the commonly-used "branch-site" models, which are used to test if positive selection has occurred on a proportion of branches. As such, aBSREL models both site-level and branch-level $\omega$  heterogeneity. aBSREL, however, does not test for selection at specific sites. Instead, aBSREL will test, for each branch (or branch of interest) in the phylogeny, whether a proportion of sites have evolved under positive selection. 
 
-aBSREL differs from other branch-site implementations by inferring the optimal number of ω categories for each branch. For example, the earlier HyPhy branch-site approach (BS-REL) assumed three ω rate categories for each branch and assigned each site, with some probability, to one of these categories. aBSREL, by contrast, acknowledges that different branches may feature more or less complex evolutionary patterns and hence may be better modeled by more or fewer ω categories. aBSREL specifically uses AIC<sub>c</sub> (small sample AIC) to infer the optimal number of rate categories for each branch. 
+aBSREL differs from other branch-site model implementations by inferring the optimal number of $\omega$  classes for each branch. For example, the earlier HyPhy branch-site approach (BS-REL) assumed three $\omega$  rate classes for each branch and assigned each site, with some probability, to one of these classes. aBSREL, by contrast, acknowledges that different branches may feature more or less complex evolutionary patterns and hence may be better modeled by more or fewer $\omega$ classes. Specifically, aBSREL uses AIC<sub>c</sub> (small sample AIC) to infer the optimal number of $\omega$ rate classes for each branch. 
 
-After aBSREL fits the full adaptive model, hypothesis testing is performed for each branch by comparing, using the Likelihood Ratio Test, the full model to a null model where branches are not allowed to have categories of ω>1. 
+After aBSREL fits the full adaptive model, the Likelihood Ratio Test is performed at each branch and compares the full model to a null model where branches are not allowed to have rate classes of $\omega>1$. 
 
-Most importantly, aBSREL can be run in two modes:
+aBSREL can be run in two modes:
 
 * Test a specific hypothesis by *a priori* selecting a set of "foreground" branches to test for positive selection. 
-* Perform an exploratory analysis where all branches are tested for positive selection. In this scenario, p-values at each branch must be corrected for multiple testing (using the Holh-Bonferroni correction). Due to multiple testing, the exploratory approach *has much lower power* compared to the other approach. 
+* Perform an exploratory analysis where all branches are tested for positive selection. In this scenario, p-values at each branch must be corrected for multiple testing (using the Holm-Bonferroni correction). Due to multiple testing, the exploratory approach *has much lower power* compared to the other approach. 
 
 
 **If you use aBSREL in your analysis, please cite the following:** [`Smith, MD et al. "Less is more: an adaptive branch-site random effects model for efficient detection of episodic diversifying selection." Mol. Biol. Evol. 32, 1342–1353 (2015).`](https://doi.org/:10.1093/molbev/msv022)
@@ -95,13 +135,13 @@ Most importantly, aBSREL can be run in two modes:
 <!--------------------------------------------------------------------------------------->
 ## BUSTED
 
-BUSTED provides a gene-wide (*not site-specific*) test for positive selection by asking whether a gene has experienced positive selection at at least one site in at least one branch. As such, BUSTED is not suitable for identifying specific sites under selection. When running BUSTED, users can either specify a set of foreground branches on which to test for positive selection (remaining branches are designated "background"), or users can test the entire phylogeny for positive selection. In the latter case, the entire tree is effectively treated as foreground, and the test for positive selection considers the entire phylogeny.
+BUSTED provides a gene-wide (*not site-specific*) test for positive selection by asking whether a gene has experienced positive selection at at least one site on at least one branch. When running BUSTED, users can either specify a set of foreground branches on which to test for positive selection (remaining branches are designated "background"), or users can test the entire phylogeny for positive selection. In the latter case, the entire tree is effectively treated as foreground, and the test for positive selection considers the entire phylogeny.
 
-For each phylogenetic partition (foreground and background branch sites), BUSTED fits a codon model with three rate categories: ω<sub>1</sub>≤ω<sub>2</sub>≤1≤ω<sub>3</sub>, and BUSTED estimates the proportion of sites per partition belonging to each ω category. This model, used as the alternative model in selection testing, is referred to as the *Unconstrained* model. BUSTED then tests for positive selection by comparing this model fit to a null model where ω<sub>3</sub>=1 (i.e. disallowing positive selection) on the foreground branches. This null model is also referred to as the *Constrained* model. If the null hypothesis is rejected, then there is evidence that at least one site has, at least some of the time, experienced positive selection on the foreground branches. Importantly, a significant result *does not* mean that the gene evolved under positive selection along the entire foreground.
+For each phylogenetic partition (foreground and background branch sites), BUSTED fits a codon model with three rate classes, constrained as $\omega_1 \leq \omega_2 \leq 1 \leq \omega_3$. As in other methods, BUSTED simultaneously estimates the proportion of sites per partition belonging to each $\omega$  class. This model, used as the alternative model in selection testing, is referred to as the *Unconstrained* model. BUSTED then tests for positive selection by comparing this model fit to a null model where $\omega_3 \geq 1$ (i.e. disallowing positive selection) on the foreground branches. This null model is also referred to as the *Constrained* model. If the null hypothesis is rejected, then there is evidence that at least one site has, at least some of the time, experienced positive selection on the foreground branches. Importantly, a significant result *does not* mean that the gene evolved under positive selection along the entire foreground.
 
-BUSTED additionally reports "Evidence Ratios" (ERs) for each site. The ER gives the likelihood ratio (reported on a log-scale) that the alternative model was a better fit to the null model. The ER for each site thus provides *descriptive information* about whether a given site could have evolved under positive selection. The ERs *should not* be interpreted as statistical evidence for positive selection at individual sites (instead, methods like [MEME](selection-methods/#MEME), [FEL](selection-methods/#FEL), or [FUBAR](selection-methods/#FUBAR) should be used for detecting selection at individual sites). 
+BUSTED additionally calculates "Evidence Ratios" (ERs) for each site. The ER gives the likelihood ratio (reported on a log-scale) that the alternative model was a better fit to the data compared to the null model. The ER for each site thus provides *descriptive information* about whether a given site could have evolved under positive selection. The ERs *should not* be interpreted as statistical evidence for positive selection at individual sites (instead, methods like [MEME](selection-methods/#MEME), [FEL](selection-methods/#FEL), or [FUBAR](selection-methods/#FUBAR) should be used for detecting selection at individual sites). 
 
-For each site, two ERs are reported: the *Constrained Model* ER and the *Optimized Null* model ER. The Constrained model ER calculates the evidence ratio using model parameters inferred from the Constrained model. By contrast the Optimized Null model ER re-optimizes parameters inferred using the Constrained model for the given site of interest. These optimized parameter values are then used to calculate the site's ER. Again, while these ERs may be helpful descriptors of selection in the data set, they do not provide statistically valid evidence for positive selection at a site.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             
+For each site, two ERs are reported: the *Constrained Model* ER and the *Optimized Null* Model ER. The Constrained Model ER calculates the evidence ratio using model parameters inferred from the Constrained model. By contrast, the Optimized Null model ER re-optimizes parameters inferred using the Constrained model for the given site of interest. These optimized parameter values are then used to calculate the site's ER. Again, while these ERs may be helpful descriptors of selection in the data set, they do not provide statistically valid evidence for positive selection at a site.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             
 
 
 **If you use BUSTED in your analysis, please cite the following:** [`Murrell, B et al. "Gene-wide identification of episodic selection." Mol. Biol. Evol. 32, 1365–1371 (2015).`](https://doi.org/10.1093/molbev/msv035)
@@ -111,17 +151,27 @@ For each site, two ERs are reported: the *Constrained Model* ER and the *Optimiz
 <!--------------------------------------------------------------------------------------->
 ## RELAX
 
-RELAX is a hypothesis testing framework that asks whether the strength of natural selection has been relaxed or intensified along a specified set of test branches. RELAX is therefore not a suitable method for explicitly testing for positive selection. Instead, RELAX is most useful for identifying trends and/or shifts in the stringency of natural selection on a given gene.
+RELAX is a hypothesis testing framework that asks whether the strength of natural selection has been relaxed or intensified along a specified set of test branches. RELAX is therefore *not* a suitable method for explicitly testing for positive selection. Instead, RELAX is most useful for identifying trends and/or shifts in the stringency of natural selection on a given gene.
 
-RELAX requires a specified set of "test" branches to compare with an additional selection of "reference" branches (note that all branches do not have to be assigned, but one branch is required the test and reference set each). RELAX begins by fitting a codon model with three ω categories to the entire phylogeny (null model). RELAX then tests for relaxed/intensified selection by introducing the parameter **k** (where k≥0), serving as the *selection intensity parameter*, as an exponent for the inferred ω values: ω<sup>k</sup>. Specifically, RELAX fixes the inferred ω values (ω<sub>1</sub>, ω<sub>2</sub>, and ω<sub>3</sub>), and infers, for the test branches, a value for *k* which modifies the rates as ω<sub>1</sub><sup>k</sup>, ω<sub>2</sub><sup>k</sup>, and ω<sub>3</sub><sup>k</sup> (alternative model). RELAX then conducts a likelihood ratio test to compare the alternative and null models. Importantly, a significant result of *k>1* indicates that selection has *been intensified* along the test branches, and a significant result of *k<1* indicates that selection has *been relaxed* along the test branches.
+RELAX requires a specified set of "test" branches to compare with a second set of "reference" branches (note that all branches do not have to be assigned, but one branch is required the test and reference set each). RELAX begins by fitting a codon model with three $\omega$  classes to the entire phylogeny (null model). RELAX then tests for relaxed/intensified selection by introducing the parameter **k** (where $k \geq 0$), serving as the *selection intensity parameter*, as an exponent for the inferred $\omega$  values: $\omega^k$. Specifically, RELAX fixes the inferred $\omega$ values (all $\omega_{<1,2,3>}$) and infers, for the test branches, a value for *k* which modifies the rates to $\omega_{<1,2,3>}^k$ (alternative model). RELAX then conducts a Likelihood Ratio Test to compare the alternative and null models. 
+
+A significant result of **k>1 indicates that selection strength has been intensified** along the test branches, and a significant result of **k<1 indicates that selection strength has been relaxed** along the test branches.
 
 In addition to this pair of null/alternative models, RELAX fits three other models meant as complementary descriptors for the data, but are not suitable for hypothesis testing. These additional models include the following:
 
-* *Partitioned MG94xREV* - This model fits a single ω value, i.e. for all sites, to each branch partition (reference and test).
-* *Partitioned Descriptive* - This model, like a more standard branch-site model, fits three ω categories separately to each branch partition (reference and test). The selection intensity parameter *k* is not included.
-* *General Descriptive* - This model fits three ω categories to the full data set, ignoring the specified test and reference partition division. It subsequently fits a *k* parameter at each branch, ultimately tailoring the three ω category values to this branch. This model may serve as a useful description of how selection intensity fluctuates over the whole tree.
+* *Partitioned MG94xREV* - This model fits a single $\omega$ value, i.e. shared for all sites, to each branch partition (reference and test). Here, a total of two $\omega$ rates are inferred.
+* *Partitioned Descriptive* - This model, like a more standard branch-site model, fits three $\omega$  classes separately to each branch partition (reference and test, producing a total of six estimated $\omega$ rates estimated). The selection intensity parameter *k* is not included.
+* *General Descriptive* - This model fits three $\omega$  classes to the full data set, ignoring the specified test and reference partition division (three total $\omega$ rates estimated). It subsequently fits a *k* parameter at each branch, ultimately tailoring the three $\omega$  class values to this branch. This model may serve as a useful description of how selection intensity fluctuates over the whole tree.
 
 
 **If you use RELAX in your analysis, please cite the following:** [`Wertheim, JO et al. "RELAX: detecting relaxed selection in a phylogenetic framework." Mol. Biol. Evol. 32, 820–832 (2015).`](https://doi.org/10.1093/molbev/msu400)
 
+<!--------------------------------------------------------------------------------------->
+
+<!--
+## FADE
+
+
+[forthcoming]
+-->
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -48,10 +48,14 @@ markdown_extensions:
   - admonition
   - toc:
       permalink: '#'
-  - mdx_math
+  - mdx_math:
+      enable_dollar_delimiter: True
+
+    
 
 extra_javascript: 
-    - http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML # Required for MathJax
+    - https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS_HTML
+    - assets/mathjaxhelper.js
 
   
 # Google Analytics
@@ -65,6 +69,7 @@ pages:
   - Glossary: 'glossary.md'
   - Support: 'support.md'
   - Selection Methods: 'selection-methods.md'
+  - Other Methods: 'other-methods.md'
   - Tutorials: 
     - Reference : 'tutorials/reference.md'
     - v2.3 Quick Start : 'tutorials/quickstart.md'

--- a/requires.txt
+++ b/requires.txt
@@ -1,1 +1,1 @@
-python-markdown-math==0.2
+pymdown-extensions


### PR DESCRIPTION
1) Glossary and selection methods and glossary have been edited and cleaned.
   - Possible change: Currently selection methods are just paragraphs of information, but could re-think to give **explicit** bullet points of Null hypothesis:... Alt hypothesis:...
   - Other possible change: Two sections of MG94 and synonyomous rate variation have been placed in selection methods somewhat (though not entirely) arbitrarily. These could be moved to the "reference" page (but linked from the selection methods page still).
    - Note, commented out FADE placeholder in selection methods.
    - Note, glossary now has shared terms section, with links at individual methods.

2) Created "Other methods" page with headers, no content, for now.
