### PR TITLE
doc: fix broken link in methods/general.md

### DIFF
--- a/docs/methods/general.md
+++ b/docs/methods/general.md
@@ -5,7 +5,7 @@ HyPhy provides a suite of tools for analyzing phylogenetic sequence data, in par
 
 <!--------------------------------------------------------------------------------------->
 ## MG94xREV Framework
-All methods used to infer selection from coding-sequence data rely, to some extent, on the MG94xREV codon model, a generalized extension of the [MG94 model](https://www.ncbi.nlm.nih.gov/labs/articles/7968485/) that allows for a full GTR mutation rate matrix. The MG94xREV *transition matrix* **Q** (also known as the *instantaneous rate matrix*), for the substitution from codon $i$ to codon $j$ is given by: 
+All methods used to infer selection from coding-sequence data rely, to some extent, on the MG94xREV codon model, a generalized extension of the [MG94 model](https://www.ncbi.nlm.nih.gov/pubmed/7968485/) that allows for a full GTR mutation rate matrix. The MG94xREV *transition matrix* **Q** (also known as the *instantaneous rate matrix*), for the substitution from codon $i$ to codon $j$ is given by: 
 
 $$\begin{equation}
 q_{ij} = \left\{ 


### PR DESCRIPTION
Link to MG94 model paper caused redirect to https://ncbiinsights.ncbi.nlm.nih.gov/2018/06/15/pubmed-journals-shut-down/
(PubMed Journals will be shut down).