### PR TITLE
Add section for stand alone analyses

### DIFF
--- a/docs/methods/index.md
+++ b/docs/methods/index.md
@@ -1,6 +1,5 @@
 # Methods
 * [General Information](/methods/general.md)
 * [Selection](/methods/selection-methods.md)
-
-## Other
+* [Stand Alone Analyses](/methods/stand-alone-analyses.md)
 * [ Evolutionary hypothesis testing](/methods/other/evo.md)

--- a/docs/methods/stand-alone-analyses.md
+++ b/docs/methods/stand-alone-analyses.md
@@ -1,0 +1,12 @@
+# Stand Alone Analyses
+
+In addition to the standard analyses that ship with HyPhy, other stand alone analyses are available [here](https://github.com/veg/hyphy-analyses).  
+
+### These analyses include:
+- [Ancestral Sequence Reconstruction](https://github.com/veg/hyphy-analyses/tree/master/AncestralSequences)
+- [Standard MG94 Fit](https://github.com/veg/hyphy-analyses/tree/master/FitMG94)
+- [Fit Multiple Hit Models](https://github.com/veg/hyphy-analyses/tree/master/FitMultiModel)
+- [Codon Models with Multiple Classes of Synonymous Codons](https://github.com/veg/hyphy-analyses/tree/master/MulticlassSynonymousSubstitutions)
+- [Simulate Codon Data with MG94 Models](https://github.com/veg/hyphy-analyses/tree/master/SimulateMG94)
+- [Codon-aware MSA](https://github.com/veg/hyphy-analyses/tree/master/codon-msa)
+- And new analyses regularly added. check the [github repository](https://github.com/veg/hyphy-analyses) for the latest.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -53,6 +53,7 @@ pages:
   - Resources: 'resources.md'
   - '_________' : 'methods/general.md'
   - '_________' : 'methods/selection-methods.md'
+  - '_________' : 'methods/stand-alone-analyses.md'
   - '_________' : 'methods/other/evo.md'
   - '________' : 'methods/other/fel-contrast.md'
   # '________' will hide the item from the toc


### PR DESCRIPTION
This just adds a simple page referencing the additional analyses that are available in https://github.com/veg/hyphy-analyses.

I tried using a plugin that is supposed to get the markdown automatically from github (https://pypi.org/project/mkdocs-snippet-plugin/) (I pushed my attempt to this branch for reference: https://github.com/rdvelazquez/hyphy-site/tree/mkdocs-snippet-plugin) but wasn't able to get it working (the repo only has two stars and doesn't seem to be widely used).